### PR TITLE
Use ocurrent versions of obuilder and ocluster.

### DIFF
--- a/roles/ocluster/tasks/main.yml
+++ b/roles/ocluster/tasks/main.yml
@@ -23,19 +23,17 @@
 
 - name: Download the source from GitHub
   git:
-    repo: https://github.com/mtelvers/ocluster.git
+    repo: https://github.com/ocurrent/ocluster.git
     dest: "{{ ansible_env.HOME }}/ocluster"
     force: yes
     recursive: no
-    version: freebsd
-
+ 
 - name: Download the source from GitHub
   git:
-    repo: https://github.com/mtelvers/obuilder.git
+    repo: https://github.com/ocurrent/obuilder.git
     dest: "{{ ansible_env.HOME }}/ocluster/obuilder"
     force: yes
     recursive: no
-    version: freebsd
 
 - name: Create opam switch
   shell: opam switch create . 4.14.1 --deps-only --with-test -y


### PR DESCRIPTION
I've merged https://github.com/ocurrent/ocluster/pull/236 and https://github.com/ocurrent/obuilder/pull/174.
We can use the versions from the main ocurrent repos.