### PR TITLE
Update opam build code

### DIFF
--- a/roles/base-image/tasks/main.yml
+++ b/roles/base-image/tasks/main.yml
@@ -64,9 +64,14 @@
       touch .hushlogin
       sed -i "" 's/^[^#]*fortune/# &/' .profile .login
       echo "OPAMCONFIRMLEVEL=unsafe-yes; export OPAMCONFIRMLEVEL" >> .profile
-      git clone -b 2.1 https://github.com/ocaml/opam opam && cd opam && gmake CONFIGURE_ARGS=--with-0install-solver cold && sudo cp -p opam /usr/local/bin/opam-2.1 && cd ../ && rm -rf opam
-      git clone -b master https://github.com/ocaml/opam opam && cd opam && gmake CONFIGURE_ARGS=--with-0install-solver cold && sudo cp -p opam /usr/local/bin/opam-dev && cd ../ && rm -rf opam
+      git config --global user.email "you@example.com"
+      git config --global user.name "Your Name"
+      git clone https://github.com/ocaml/opam /home/opam/opam && cd /home/opam/opam && cp -P -R -p . ../opam-sources && git checkout 62ad0c21768e28532466572dbaa066913a6c050d && git remote add mtelvers https://github.com/mtelvers/opam && git fetch mtelvers && git cherry-pick bfa86fcc5187bf71080d5f934ff147cdbb64a9e1 && env MAKE='gmake -j' shell/bootstrap-ocaml.sh && gmake -C src_ext cache-archives
+      cd /home/opam/opam-sources && cp -P -R -p . ../opam-build-2.0 && cd ../opam-build-2.0 && git checkout 2.0 && ln -s ../opam/src_ext/archives src_ext/archives && env PATH="/home/opam/opam/bootstrap/ocaml/bin:$PATH" ./configure --enable-cold-check && env PATH="/home/opam/opam/bootstrap/ocaml/bin:$PATH" gmake lib-ext all && mkdir -p /usr/local/bin && sudo cp /home/opam/opam-build-2.0/opam /usr/local/bin/opam-2.0 && sudo chmod a+x /usr/local/bin/opam-2.0 && rm -rf /home/opam/opam-build-2.0
+      cd /home/opam/opam-sources && cp -P -R -p . ../opam-build-2.1 && cd ../opam-build-2.1 && git checkout 2.1 && ln -s ../opam/src_ext/archives src_ext/archives && env PATH="/home/opam/opam/bootstrap/ocaml/bin:$PATH" ./configure --enable-cold-check --with-0install-solver && env PATH="/home/opam/opam/bootstrap/ocaml/bin:$PATH" gmake lib-ext all && mkdir -p /usr/local/bin && sudo cp /home/opam/opam-build-2.1/opam /usr/local/bin/opam-2.1 && sudo chmod a+x /usr/local/bin/opam-2.1 && rm -rf /home/opam/opam-build-2.1
+      cd /home/opam/opam-sources && cp -P -R -p . ../opam-build-master && cd ../opam-build-master && git checkout master && ln -s ../opam/src_ext/archives src_ext/archives && env PATH="/home/opam/opam/bootstrap/ocaml/bin:$PATH" ./configure --enable-cold-check --with-0install-solver --with-vendored-deps && env PATH="/home/opam/opam/bootstrap/ocaml/bin:$PATH" gmake lib-ext all && mkdir -p /usr/local/bin && sudo cp /home/opam/opam-build-master/opam /usr/local/bin/opam-dev && sudo chmod a+x /usr/local/bin/opam-master && rm -rf /home/opam/opam-build-master
       sudo ln /usr/local/bin/opam-2.1 /usr/local/bin/opam
+      cd /home/opam
       git clone https://github.com/ocaml/opam-repository.git
       opam init -k git -a ./opam-repository -c {{ version }} -y
   when: version != "busybox"


### PR DESCRIPTION
This update means that we only build the bootstrap compiler once and using that we build Opam 2.0, 2.1 and Dev.  This more closely mirrors the Docker base images of the other distributions.