### PR TITLE
Updates for FreeBSD 14.1

### DIFF
--- a/roles/base-image/files/jail
+++ b/roles/base-image/files/jail
@@ -54,7 +54,7 @@ mkdir -p $1 || error "mkdir failed for $1"
 test ! -d $BSDINSTALL_DISTDIR && mkdir -p $BSDINSTALL_DISTDIR
 
 if [ ! -f $BSDINSTALL_DISTDIR/MANIFEST -a -z "$BSDINSTALL_DISTSITE" ]; then
-	export BSDINSTALL_DISTSITE="https://download.freebsd.org/ftp/releases/amd64/amd64/14.0-RELEASE"
+	export BSDINSTALL_DISTSITE="https://download.freebsd.org/ftp/releases/amd64/amd64/14.1-RELEASE"
 	fetch -o $BSDINSTALL_DISTDIR/MANIFEST $BSDINSTALL_DISTSITE/MANIFEST || error "Could not download $BSDINSTALL_DISTSITE/MANIFEST"
 fi
 

--- a/roles/ocluster/tasks/main.yml
+++ b/roles/ocluster/tasks/main.yml
@@ -13,8 +13,7 @@
       rm install.sh
       chmod +x opam-*
       mv opam-* /usr/local/bin/opam
-      sudo ln /usr/local/bin/opam-2.1 /usr/local/bin/opam
-      opam init -y
+      opam init --bare -y
 
 - name: Remove ~/ocluster
   file:
@@ -36,7 +35,7 @@
     recursive: no
 
 - name: Create opam switch
-  shell: opam switch create . 4.14.1 --deps-only --with-test --confirm-level=unsafe-yes
+  shell: opam switch create . 4.14.2 --deps-only --with-test --confirm-level=unsafe-yes
   args:
     chdir: "{{ ansible_env.HOME }}/ocluster"
 


### PR DESCRIPTION
Updates for FreeBSD 14.1 - https://github.com/ocaml/infrastructure/issues/162

Plus using opam 2.2 on the host machine rather than 2.1 and build with OCaml 4.14.2.